### PR TITLE
#53 fix server hooks file location in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ The secret is a private key or list of private keys you must pass at runtime, it
 
 ### Initializing
 
-> src/hooks.ts || src/hooks/index.ts
+> src/hooks.server.ts
 
 ```js
 import { handleSession } from 'svelte-kit-cookie-session';


### PR DESCRIPTION
in svelte-kit, [the server hooks file](https://kit.svelte.dev/docs/hooks) was moved to `src/hooks.server.ts` instead of `src/hooks.ts`.