### PR TITLE
Compatibility with cookie@1.0

### DIFF
--- a/src/lib/core.ts
+++ b/src/lib/core.ts
@@ -86,7 +86,7 @@ export class CookieSession<SessionType = Record<string, any>> {
 		let maxAge = this.#config.cookie.maxAge;
 
 		if (this.#sessionData?.expires) {
-			maxAge = new Date(this.#sessionData.expires).getTime() / 1000 - new Date().getTime() / 1000;
+			maxAge = Math.round(new Date(this.#sessionData.expires).getTime() / 1000 - new Date().getTime() / 1000);
 		}
 
 		this.#state.needsSync = true;
@@ -143,7 +143,7 @@ export class CookieSession<SessionType = Record<string, any>> {
 		let maxAge = this.#config.cookie.maxAge;
 
 		if (this.#sessionData?.expires) {
-			maxAge = new Date(this.#sessionData.expires).getTime() / 1000 - new Date().getTime() / 1000;
+			maxAge = Math.round(new Date(this.#sessionData.expires).getTime() / 1000 - new Date().getTime() / 1000);
 		}
 
 		await this.setCookie(maxAge);

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -5,11 +5,11 @@ import type { MaybePromise } from '@sveltejs/kit';
 export function expiresToMaxage(expires: number, expires_in: 'days' | 'hours' | 'minutes' | 'seconds') {
 	switch (expires_in) {
 		case 'days':
-			return expires * 24 * 60 * 60;
+			return Math.round(expires * 24 * 60 * 60);
 		case 'hours':
-			return expires * 60 * 60;
+			return Math.round(expires * 60 * 60);
 		case 'minutes':
-			return expires * 60;
+			return Math.round(expires * 60);
 		case 'seconds':
 			return expires;
 		default:


### PR DESCRIPTION
While SvelteKit still depends on cookie@0.6 (due to breaking changes discussed in sveltejs/kit#12767), this version of 'cookie' is affected by  [CVE-2024-47764](https://github.com/jshttp/cookie/security/advisories/GHSA-pxg6-pf52-xh8x).

As stated in the above PR, it may be advisable for some users to manually override the 'cookie' version to 0.7 or up. The recent release of cookie@1.0, however, added strict checks to ensure maxAge-values are integers (using Number.isInteger), which breaks the current method of calculating the max-age for the session-cookie.

This PR ensures that the calculated max-age values are rounded before being used in setCookie.

To ensure that this update is mostly non-breaking, the 'expiresToMaxage' utility-function was also adapted to round the max-age when calculating from days, hours and minutes. When 'calculating' from seconds, no rounding is applied to match cookie's behavior.
While it is not advisable, this means that non-integer expiry-values (such as 0.5 days) are still valid, even when using cookie@1.0.